### PR TITLE
Change the way the parser recognizes geo spacial strings

### DIFF
--- a/MapPointMapper/Parser/Parser.swift
+++ b/MapPointMapper/Parser/Parser.swift
@@ -10,8 +10,19 @@ import Foundation
 import MapKit
 
 extension NSString {
+    /*!
+    */
     var isEmpty: Bool {
         get { return self.length == 0 || self.isEqualToString("") }
+    }
+}
+extension String {
+    /*!
+    */
+    func stringByStrippingLeadingAndTrailingWhiteSpace() -> String {
+        let mutable = self.mutableCopy() as NSMutableString
+        CFStringTrimWhitespace(mutable)
+        return mutable.copy() as String
     }
 }
 
@@ -132,6 +143,7 @@ class Parser {
     output => "( 15 32 )"
     */
     internal func stripExtraneousCharacters(input: NSString) -> NSString {
+
         let regex = NSRegularExpression(pattern: "\\D+\\s+\\((.*)\\)", options: .CaseInsensitive, error: nil)
         let match: AnyObject? = regex?.matchesInString(input, options: .ReportCompletion, range: NSMakeRange(0, input.length)).first
         let range = match?.rangeAtIndex(1)
@@ -143,7 +155,8 @@ class Parser {
     }
     
     internal func isProbablyGeoString(input: String) -> Bool {
-        if let geoString = input.rangeOfString("^\\D+", options: .RegularExpressionSearch) {
+        let stripped = input.stringByStrippingLeadingAndTrailingWhiteSpace()
+        if let geoString = stripped.rangeOfString("^\\w+", options: .RegularExpressionSearch) {
             return true
         }
         return false

--- a/MapPointMapper/ViewController.swift
+++ b/MapPointMapper/ViewController.swift
@@ -167,8 +167,10 @@ class ViewController: NSViewController, MKMapViewDelegate, NSTextFieldDelegate {
                 NSAlert(error: err)
                 return
             }
-            
-            renderInput(contents!)
+
+            if let content = contents {
+                renderInput(content)
+            }
         }
     } // end readFileAtURL
     
@@ -182,9 +184,9 @@ class ViewController: NSViewController, MKMapViewDelegate, NSTextFieldDelegate {
     }
 
     private func parseInput(input: NSString) {
-        
-        let coordinates = Parser.parseString(input, longitudeFirst: parseLongitudeFirst)
-        
+
+        let coordinates = Parser.parseString(input, longitudeFirst: parseLongitudeFirst).filter({!$0.isEmpty})
+
         var polylines = [MKOverlay]()
         for coordianteSet in coordinates {
             let polyline = createPolylineForCoordinates(coordianteSet)
@@ -192,8 +194,10 @@ class ViewController: NSViewController, MKMapViewDelegate, NSTextFieldDelegate {
             polylines.append(polyline)
         }
 
-        let boundingMapRect = boundingMapRectForPolylines(polylines)
-        mapview.setVisibleMapRect(boundingMapRect, edgePadding: NSEdgeInsets(top: 10, left: 10, bottom: 10, right: 10), animated: true)
+        if !polylines.isEmpty {
+            let boundingMapRect = boundingMapRectForPolylines(polylines)
+            mapview.setVisibleMapRect(boundingMapRect, edgePadding: NSEdgeInsets(top: 10, left: 10, bottom: 10, right: 10), animated: true)
+        }
     }
 }
 

--- a/MapPointMapperTests/Parser/ParserTests.swift
+++ b/MapPointMapperTests/Parser/ParserTests.swift
@@ -34,6 +34,10 @@ class ParserSpec: XCTestCase {
     XCTAssertFalse(parser.isProbablyGeoString(unknown), "'unknown' should not be a geospacial string")
   }
   
+  func testParserKnowsItsNotGeoSpacialEvenIfItsClose() {
+    XCTAssertFalse(parser.isProbablyGeoString("-122 45"), "'-122 45' should not be geospacial")
+  }
+  
   func testIsMultiItem() {
     XCTAssertTrue(parser.isMultiItem(multiPolygon), "'multipolygon' should be a multi item")
     XCTAssertTrue(parser.isMultiItem(multiLine), "'multiline' should be a multi item")


### PR DESCRIPTION
Previously a negative number would give a false positive to a geo spacial
style string however that is not the case so this fixes that failed
check & also does not try to center the map to an empty set of
`MKOverlay` objects
